### PR TITLE
Update update_checker.py

### DIFF
--- a/update_checker.py
+++ b/update_checker.py
@@ -109,7 +109,7 @@ class UpdateChecker(object):
         data['platform'] = platform.platform(True)
 
         try:
-            headers = {'content-type': 'application/json'}
+            headers = {'content-type': 'application/json', 'Connection': 'close'}
             response = requests.put(self.url, json.dumps(data), timeout=1,
                                     headers=headers)
             data = response.json()


### PR DESCRIPTION
Added connection close to header. Python 3.3 has this semi-dumb bug where the resource checker runs before the next 'line' of a program when you work with sockets. If you don't add a 'connection -> close' header, the socket stays open for a tiny period of time after you call it, and python throws a resource warning. The header makes the server close the socket when you are done with whatever you requested. It doesn't make a difference in real world but it prevents the resource warning from appearing.
