### PR TITLE
Update for version 0.18

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E203 E501 W503 W504

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-script: python setup.py test
+  - 3.6
+  - 3.7
+  - 3.8
+script: pytest
 install:
-  - python setup.py install
+  - pip install -e .[dev]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,43 @@
-#!/usr/bin/env python
 import os
 import re
 from setuptools import setup
 
-MODULE_NAME = 'update_checker'
+MODULE_NAME = "update_checker"
 
-with open(os.path.join(os.path.dirname(__file__), 'README.md')) as fp:
+with open(os.path.join(os.path.dirname(__file__), "README.md")) as fp:
     README = fp.read()
-with open('{0}.py'.format(MODULE_NAME)) as fp:
-    VERSION = re.search("__version__ = '([^']+)'", fp.read()).group(1)
+with open(f"{MODULE_NAME}.py") as fp:
+    VERSION = re.search('__version__ = "([^"]+)"', fp.read()).group(1)
 
-setup(name=MODULE_NAME,
-      author='Bryce Boe',
-      author_email='bbzbryce@gmail.com',
-      classifiers=['Intended Audience :: Developers',
-                   'License :: OSI Approved :: BSD License',
-                   'Operating System :: OS Independent',
-                   'Programming Language :: Python',
-                   'Programming Language :: Python :: 2.7',
-                   'Programming Language :: Python :: 3',
-                   'Programming Language :: Python :: 3.3',
-                   'Programming Language :: Python :: 3.4',
-                   'Programming Language :: Python :: 3.5'],
-      description='A python module that will check for package updates.',
-      install_requires=['requests>=2.3.0'],
-      license='Simplified BSD License',
-      long_description=README,
-      long_description_content_type='text/markdown',
-      py_modules=[MODULE_NAME, '{0}_test'.format(MODULE_NAME)],
-      test_suite='update_checker_test',
-      url='https://github.com/bboe/update_checker',
-      version=VERSION)
+
+extras = {
+    "dev": [],
+    "lint": ["black", "flake8"],
+    "test": ["pytest >=2.7.3"],
+}
+extras["dev"] += extras["lint"] + extras["test"]
+
+setup(
+    name=MODULE_NAME,
+    author="Bryce Boe",
+    author_email="bbzbryce@gmail.com",
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+    ],
+    description="A python module that will check for package updates.",
+    extras_require=extras,
+    install_requires=["requests>=2.3.0"],
+    license="Simplified BSD License",
+    long_description=README,
+    long_description_content_type="text/markdown",
+    py_modules=[MODULE_NAME, f"{MODULE_NAME}_test"],
+    url="https://github.com/bboe/update_checker",
+    version=VERSION,
+)

--- a/update_checker_test.py
+++ b/update_checker_test.py
@@ -1,81 +1,76 @@
-#!/usr/bin/env python
-import sys
-import unittest
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO  # NOQA
+from unittest import mock
+
+import requests
 from update_checker import UpdateChecker, update_check
 
 
-class UpdateCheckerTest(unittest.TestCase):
-    TRACKED_PACKAGE = 'praw'
-    UNTRACKED_PACKAGE = 'requests'
-
-    def test_checker_check__bad_url(self):
-        checker = UpdateChecker('http://sdlkjsldfkjsdlkfj.com')
-        checker.bypass_cache = True
-        self.assertFalse(checker.check(self.TRACKED_PACKAGE, '0.0.1'))
-
-    def test_checker_check__no_update_to_beta_version(self):
-        checker = UpdateChecker()
-        checker.bypass_cache = True
-        self.assertFalse(checker.check(self.TRACKED_PACKAGE, '3.6'))
-
-    def test_check_check__untracked_package(self):
-        checker = UpdateChecker()
-        checker.bypass_cache = True
-        self.assertEqual("update_checker does not support 'requests'",
-                         checker.check(self.UNTRACKED_PACKAGE, '0.0.1'))
-
-    def test_checker_check__update_to_beta_version_from_beta_version(self):
-        checker = UpdateChecker()
-        checker.bypass_cache = True
-        self.assertTrue(checker.check(self.TRACKED_PACKAGE, '4.0.0b4'))
-
-    def test_checker_check__update_to_rc_version_from_beta_version(self):
-        checker = UpdateChecker()
-        checker.bypass_cache = True
-        self.assertTrue(checker.check(self.TRACKED_PACKAGE, '4.0.0b4'))
-
-    def test_checker_check__successful(self):
-        checker = UpdateChecker()
-        checker.bypass_cache = True
-        result = checker.check(self.TRACKED_PACKAGE, '1.0.0')
-        self.assertTrue(result is not None)
-
-    def test_update_check__successful(self):
-        prev_stdout = sys.stdout
-        sys.stdout = StringIO()
-        try:
-            update_check(self.TRACKED_PACKAGE, '0.0.1', bypass_cache=True)
-        finally:
-            result = sys.stdout
-            sys.stdout = prev_stdout
-        self.assertTrue(len(result.getvalue()) > 0)
-
-    def test_update_check__unsuccessful(self):
-        prev_stdout = sys.stdout
-        sys.stdout = StringIO()
-        try:
-            update_check(self.TRACKED_PACKAGE, '0.0.1', bypass_cache=True,
-                         url='http://sdlkjsldfkjsdlkfj.com')
-        finally:
-            result = sys.stdout
-            sys.stdout = prev_stdout
-        self.assertTrue(len(result.getvalue()) == 0)
-
-    def test_update_check__untracked_package(self):
-        prev_stdout = sys.stdout
-        sys.stdout = StringIO()
-        try:
-            update_check(self.UNTRACKED_PACKAGE, '0.0.1', bypass_cache=True)
-        finally:
-            result = sys.stdout
-            sys.stdout = prev_stdout
-        self.assertEqual("update_checker does not support 'requests'\n",
-                         result.getvalue())
+PACKAGE = "praw"
 
 
-if __name__ == '__main__':
-    unittest.main()
+def mock_response(response, latest_version="5.0.0"):
+    response.json = mock.Mock(
+        return_value={"releases": {"0.0.1": [], latest_version: []}}
+    )
+    response.status_code = 200
+
+
+@mock.patch("requests.get")
+def test_checker_check__no_update_to_beta_version(mock_get):
+    mock_response(mock_get.return_value, "3.7.0b1")
+    checker = UpdateChecker(bypass_cache=True)
+    assert checker.check(PACKAGE, "3.6") is None
+
+
+@mock.patch("requests.get")
+def test_checker_check__update_to_beta_version_from_beta_version(mock_get):
+    mock_response(mock_get.return_value, "4.0.0b5")
+    checker = UpdateChecker(bypass_cache=True)
+    result = checker.check(PACKAGE, "4.0.0b4")
+    assert result.available_version == "4.0.0b5"
+
+
+@mock.patch("requests.get")
+def test_checker_check__update_to_rc_version_from_beta_version(mock_get):
+    mock_response(mock_get.return_value, "4.0.0rc1")
+    checker = UpdateChecker(bypass_cache=True)
+    result = checker.check(PACKAGE, "4.0.0b4")
+    assert result.available_version == "4.0.0rc1"
+
+
+@mock.patch("requests.get")
+def test_checker_check__successful(mock_get):
+    mock_response(mock_get.return_value)
+    checker = UpdateChecker(bypass_cache=True)
+    result = checker.check(PACKAGE, "1.0.0")
+    assert result.available_version == "5.0.0"
+
+
+@mock.patch("requests.get")
+def test_checker_check__unsuccessful(mock_get):
+    mock_get.side_effect = requests.exceptions.RequestException
+    checker = UpdateChecker(bypass_cache=True)
+    assert checker.check(PACKAGE, "1.0.0") is None
+
+
+@mock.patch("requests.get")
+def test_update_check__successful__has_no_update(mock_get, capsys):
+    mock_response(mock_get.return_value, "0.0.2")
+    update_check(PACKAGE, "0.0.2", bypass_cache=True)
+    assert "" == capsys.readouterr().err
+
+
+@mock.patch("requests.get")
+def test_update_check__successful__has_update(mock_get, capsys):
+    mock_response(mock_get.return_value)
+    update_check(PACKAGE, "0.0.1", bypass_cache=True)
+    assert (
+        "Version 0.0.1 of praw is outdated. Version 5.0.0 is available.\n"
+        == capsys.readouterr().err
+    )
+
+
+@mock.patch("requests.get")
+def test_update_check__unsuccessful(mock_get, capsys):
+    mock_get.side_effect = requests.exceptions.RequestException
+    update_check(PACKAGE, "0.0.1", bypass_cache=True)
+    assert "" == capsys.readouterr().err


### PR DESCRIPTION
There are a ton of changes here which I simply do not feel like taking the time to make atomic.

* Apply the tool black against the project.
* Only support python 3.6+
  * Convert uses of string.format to f-strings.
* Query results directly from pypi rather than from a server running update_checker_app.
* Convert tests to use pytest.
  * Mock actual requests so the tests are consistent.