### PR TITLE
Reference uv instead of pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ author for information on adding a package to the whitelist.
 
 The update_checker module can be installed via:
 
-    pip install update_checker
+    uv add update_checker
 
 ### Usage
 
@@ -44,7 +44,7 @@ if result:  # result is None when an update was not found or a failure occured
 
 ### Async usage
 
-Install the `async` extra (`pip install update_checker[async]`) and use the
+Install the `async` extra (`uv add "update_checker[async]"`) and use the
 async counterparts:
 
 ```python

--- a/src/update_checker/core.py
+++ b/src/update_checker/core.py
@@ -282,7 +282,7 @@ async def async_query_pypi(
 
     """
     if aiohttp is None:
-        msg = "aiohttp is required for async support: pip install update_checker[async]"
+        msg = 'aiohttp is required for async support: uv add "update_checker[async]"'
         raise ImportError(msg)
     timeout = aiohttp.ClientTimeout(total=1)
     try:


### PR DESCRIPTION
Replaces the remaining pip references with uv, matching the project's tooling:

- README install: `pip install update_checker` → `uv add update_checker`
- README async extra: `pip install update_checker[async]` → `uv add "update_checker[async]"`
- The aiohttp `ImportError` message now suggests `uv add "update_checker[async]"` (quoted, since the bracket is a shell glob)