### PR TITLE
Harden the PyPI network and cache paths

### DIFF
--- a/src/update_checker/core.py
+++ b/src/update_checker/core.py
@@ -12,11 +12,13 @@ import string
 import sys
 import time
 import urllib.request
+import zlib
 from datetime import datetime, timezone
 from functools import wraps
 from http import HTTPStatus
 from importlib.metadata import version
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 try:
     import aiohttp
@@ -25,16 +27,23 @@ except ImportError:  # aiohttp is only required for async support
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterator
+    from http.client import HTTPResponse
 
 __version__ = version("update_checker")
 
 CACHE_MISS = object()
+CHUNK_SIZE = 65536
 # COMPONENT_RE and REPLACE support parse_version near the bottom of this module
 COMPONENT_RE = re.compile(r"(\d+ | [a-z]+ | \.| -)", re.VERBOSE)
 DAYS_PER_WEEK = 7
+# A runaway guard against memory exhaustion. This bounds the decompressed
+# response, so it must stay above the largest real PyPI JSON (a few MiB);
+# gzip shrinks the transfer but not the parsed payload this limit governs.
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
 REPLACE = {"-": "final-", "dev": "@", "pre": "c", "preview": "c", "rc": "c"}.get
 SECONDS_PER_HOUR = 3600
 SECONDS_PER_MINUTE = 60
+TIMEOUT_SECONDS = 1
 
 
 class _Cache:
@@ -84,7 +93,7 @@ class _Cache:
         """
         self.update_from_permacache()
         data = {
-            "|".join(key): [cache_time, _serialize_result(result)]
+            json.dumps(key): [cache_time, _serialize_result(result)]
             for key, (cache_time, result) in self.results.items()
         }
         try:
@@ -110,7 +119,7 @@ class _Cache:
             return  # It's okay if it cannot load
         try:
             for raw_key, (cache_time, result) in permacache.items():
-                key = tuple(raw_key.split("|", 1))
+                key = tuple(json.loads(raw_key))
                 if key not in self.results or cache_time > self.results[key][0]:
                     self.results[key] = (cache_time, _deserialize_result(result))
         except (AttributeError, KeyError, TypeError, ValueError):
@@ -284,15 +293,22 @@ async def async_query_pypi(
     if aiohttp is None:
         msg = 'aiohttp is required for async support: uv add "update_checker[async]"'
         raise ImportError(msg)
-    timeout = aiohttp.ClientTimeout(total=1)
+    timeout = aiohttp.ClientTimeout(total=TIMEOUT_SECONDS)
     try:
         async with (
             aiohttp.ClientSession(timeout=timeout) as session,
-            session.get(f"https://pypi.org/pypi/{package}/json") as response,
+            session.get(
+                f"https://pypi.org/pypi/{quote(package, safe='')}/json",
+            ) as response,
         ):
             if response.status != HTTPStatus.OK:
                 return {"success": False}
-            json_data = await response.json()
+            # Cap the body so a hostile response cannot exhaust memory; the
+            # total timeout above already bounds how long reading may take
+            raw = await response.content.read(MAX_RESPONSE_BYTES + 1)
+            if len(raw) > MAX_RESPONSE_BYTES:
+                return {"success": False}
+            json_data = json.loads(raw)
     # TimeoutError and asyncio.TimeoutError are distinct prior to Python 3.11
     except (TimeoutError, ValueError, aiohttp.ClientError, asyncio.TimeoutError):
         return {"success": False}
@@ -437,6 +453,20 @@ def _extract_version(
     return {"upload_time": upload_time, "version": version}
 
 
+def _gunzip_capped(data: bytes, /) -> bytes:
+    # wbits of MAX_WBITS | 16 selects the gzip format
+    decompressor = zlib.decompressobj(wbits=zlib.MAX_WBITS | 16)
+    try:
+        result = decompressor.decompress(data, MAX_RESPONSE_BYTES + 1)
+    except zlib.error as exception:
+        msg = "response could not be decompressed"
+        raise ValueError(msg) from exception
+    if len(result) > MAX_RESPONSE_BYTES or decompressor.unconsumed_tail:
+        msg = "decompressed response exceeded the maximum allowed size"
+        raise ValueError(msg)
+    return result
+
+
 # The following two functions are taken from setuptools pkg_resources.py (PSF
 # license), along with the COMPONENT_RE and REPLACE constants near the top of
 # this module. Unfortunately importing pkg_resources to directly use the
@@ -544,11 +574,18 @@ def query_pypi(*, include_prereleases: bool, package: str) -> dict[str, Any]:
         with "version" and "upload_time" keys.
 
     """
-    url = f"https://pypi.org/pypi/{package}/json"
+    # build_opener keeps the default handlers (notably proxy support) while
+    # letting us request a gzip-compressed response
+    opener = urllib.request.build_opener()
+    opener.addheaders = [("Accept-Encoding", "gzip")]
+    url = f"https://pypi.org/pypi/{quote(package, safe='')}/json"
     try:
-        # urlopen raises HTTPError, an OSError, for non-2xx responses
-        with urllib.request.urlopen(url, timeout=1) as response:
-            json_data = json.load(response)
+        # open raises HTTPError, an OSError, for non-2xx responses
+        with opener.open(url, timeout=TIMEOUT_SECONDS) as response:
+            raw = _read_capped(response)
+            encoding = response.headers.get("Content-Encoding")
+        raw = _gunzip_capped(raw) if encoding == "gzip" else raw
+        json_data = json.loads(raw)
     except (OSError, ValueError):
         return {"success": False}
     try:
@@ -560,6 +597,22 @@ def query_pypi(*, include_prereleases: bool, package: str) -> dict[str, Any]:
         return {"success": False}  # Ignore malformed responses
 
     return {"success": True, "data": data}
+
+
+def _read_capped(response: HTTPResponse, /) -> bytes:
+    deadline = time.monotonic() + TIMEOUT_SECONDS
+    chunks: list[bytes] = []
+    total = 0
+    while chunk := response.read(CHUNK_SIZE):
+        total += len(chunk)
+        if total > MAX_RESPONSE_BYTES:
+            msg = "response exceeded the maximum allowed size"
+            raise ValueError(msg)
+        if time.monotonic() > deadline:
+            msg = "response exceeded the time budget"
+            raise ValueError(msg)
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _result_from_data(

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gzip
 import io
 import json
 import os
@@ -20,9 +21,16 @@ from update_checker import (
     pretty_date,
     update_check,
 )
-from update_checker.core import _colorize, _deserialize_result, _serialize_result
+from update_checker.core import (
+    _Cache,
+    _colorize,
+    _deserialize_result,
+    _serialize_result,
+    query_pypi,
+)
 
 if TYPE_CHECKING:
+    import pathlib
     from typing import Self
 
     import pytest
@@ -30,12 +38,38 @@ if TYPE_CHECKING:
 PACKAGE = "praw"
 
 
+class FakeContent:
+    """Stand-in for the StreamReader exposed by an aiohttp response."""
+
+    def __init__(self, body: bytes, /) -> None:
+        """Initialize a FakeContent instance."""
+        self._body = body
+
+    async def read(self, size: int = -1, /) -> bytes:
+        """Return up to size bytes of the canned body.
+
+        Returns:
+            The first size bytes of the body, or all of it when size is
+            negative.
+
+        """
+        return self._body if size < 0 else self._body[:size]
+
+
 class FakeResponse:
     """Async context manager standing in for an aiohttp response."""
 
-    def __init__(self, *, json_data: object = None, status: int = 200) -> None:
+    def __init__(
+        self,
+        *,
+        body: bytes | None = None,
+        json_data: object = None,
+        status: int = 200,
+    ) -> None:
         """Initialize a FakeResponse instance."""
-        self.json_data = json_data
+        if body is None:
+            body = b"" if json_data is None else json.dumps(json_data).encode()
+        self.content = FakeContent(body)
         self.status = status
 
     async def __aenter__(self) -> Self:
@@ -49,17 +83,6 @@ class FakeResponse:
 
     async def __aexit__(self, *_exc_info: object) -> None:
         """Do nothing."""
-
-    async def json(self) -> object:
-        """Return the canned JSON payload, or raise the canned exception.
-
-        Returns:
-            The canned JSON payload.
-
-        """
-        if isinstance(self.json_data, Exception):
-            raise self.json_data
-        return self.json_data
 
 
 class FakeSession:
@@ -98,19 +121,39 @@ class FakeSession:
         return self._response
 
 
+class FakeSyncResponse(io.BytesIO):
+    """Context manager standing in for an HTTPResponse from urlopen."""
+
+    def __init__(self, body: bytes, /, *, content_encoding: str | None = None) -> None:
+        """Initialize a FakeSyncResponse instance."""
+        super().__init__(body)
+        self.headers = (
+            {"Content-Encoding": content_encoding} if content_encoding else {}
+        )
+
+
 def fake_async_pypi(response: FakeResponse | Exception, /) -> mock._patch:
     return mock.patch("aiohttp.ClientSession", partial(FakeSession, response))
 
 
-def fake_sync_pypi(response: bytes | Exception | object, /) -> mock._patch:
+def fake_sync_pypi(
+    response: bytes | Exception | object,
+    /,
+    *,
+    content_encoding: str | None = None,
+) -> mock._patch:
+    target = "urllib.request.OpenerDirector.open"
     if isinstance(response, Exception):
-        return mock.patch("urllib.request.urlopen", side_effect=response)
+        return mock.patch(target, side_effect=response)
     body = response if isinstance(response, bytes) else json.dumps(response).encode()
-    return mock.patch("urllib.request.urlopen", return_value=io.BytesIO(body))
+    return mock.patch(
+        target,
+        return_value=FakeSyncResponse(body, content_encoding=content_encoding),
+    )
 
 
 async def test_async_checker_check__malformed_json() -> None:
-    with fake_async_pypi(FakeResponse(json_data=ValueError("not json"))):
+    with fake_async_pypi(FakeResponse(body=b"not json")):
         checker = UpdateChecker(bypass_cache=True)
         result = await checker.async_check(
             package_name=PACKAGE,
@@ -121,6 +164,20 @@ async def test_async_checker_check__malformed_json() -> None:
 
 async def test_async_checker_check__missing_releases() -> None:
     with fake_async_pypi(FakeResponse(json_data={})):
+        checker = UpdateChecker(bypass_cache=True)
+        result = await checker.async_check(
+            package_name=PACKAGE,
+            package_version="1.0.0",
+        )
+    assert result is None
+
+
+async def test_async_checker_check__oversized_response() -> None:
+    response = FakeResponse(json_data={"releases": {"0.0.1": [], "5.0.0": []}})
+    with (
+        mock.patch("update_checker.core.MAX_RESPONSE_BYTES", 4),
+        fake_async_pypi(response),
+    ):
         checker = UpdateChecker(bypass_cache=True)
         result = await checker.async_check(
             package_name=PACKAGE,
@@ -214,6 +271,29 @@ async def test_async_update_check__unsuccessful(
     assert not capsys.readouterr().err
 
 
+def test_cache_permacache__round_trips_keys_with_special_characters(
+    tmp_path: pathlib.Path,
+) -> None:
+    key = ("name|with|pipes", "1.0")
+    writer = _Cache()
+    writer.filename = tmp_path / "cache.json"
+    writer.initialized = True
+    writer.store(key=key, value=None)
+
+    reader = _Cache()
+    reader.filename = tmp_path / "cache.json"
+    reader.update_from_permacache()
+    assert key in reader.results
+
+
+def test_checker_check__gzip_encoded_response() -> None:
+    body = gzip.compress(json.dumps({"releases": {"0.0.1": [], "5.0.0": []}}).encode())
+    with fake_sync_pypi(body, content_encoding="gzip"):
+        checker = UpdateChecker(bypass_cache=True)
+        result = checker.check(package_name=PACKAGE, package_version="1.0.0")
+    assert result.available_version == "5.0.0"
+
+
 def test_checker_check__malformed_json() -> None:
     with fake_sync_pypi(b"not json"):
         checker = UpdateChecker(bypass_cache=True)
@@ -232,6 +312,27 @@ def test_checker_check__no_update_to_beta_version() -> None:
     with fake_sync_pypi({"releases": {"0.0.1": [], "3.7.0b1": []}}):
         checker = UpdateChecker(bypass_cache=True)
         result = checker.check(package_name=PACKAGE, package_version="3.6")
+    assert result is None
+
+
+def test_checker_check__oversized_decompressed_response() -> None:
+    body = gzip.compress(json.dumps({"releases": {"x" * 10000: []}}).encode())
+    with (
+        mock.patch("update_checker.core.MAX_RESPONSE_BYTES", len(body) + 100),
+        fake_sync_pypi(body, content_encoding="gzip"),
+    ):
+        checker = UpdateChecker(bypass_cache=True)
+        result = checker.check(package_name=PACKAGE, package_version="1.0.0")
+    assert result is None
+
+
+def test_checker_check__oversized_response() -> None:
+    with (
+        mock.patch("update_checker.core.MAX_RESPONSE_BYTES", 4),
+        fake_sync_pypi({"releases": {"0.0.1": [], "5.0.0": []}}),
+    ):
+        checker = UpdateChecker(bypass_cache=True)
+        result = checker.check(package_name=PACKAGE, package_version="1.0.0")
     assert result is None
 
 
@@ -301,6 +402,12 @@ def test_pretty_date__naive_datetime() -> None:
     # previous versions, are interpreted as UTC
     naive_utc = datetime.now(timezone.utc).replace(tzinfo=None)
     assert pretty_date(naive_utc - timedelta(days=3)) == "3 days ago"
+
+
+def test_query_pypi__quotes_package_name() -> None:
+    with fake_sync_pypi({}) as opener_open:
+        query_pypi(include_prereleases=False, package="a/b c")
+    assert opener_open.call_args.args[0] == "https://pypi.org/pypi/a%2Fb%20c/json"
 
 
 def test_serialize_result__round_trip() -> None:


### PR DESCRIPTION
Defense-in-depth follow-up to the earlier security hardening, plus a response-size optimization. The audit turned up only low-severity items (the host is `pypi.org` over HTTPS), but each is cheap to close.

## Hardening

- **Response size cap (memory DoS).** Both `query_pypi` and `async_query_pypi` cap the body at **64 MiB**. The largest real PyPI JSON responses are only a few MiB (numpy ~3 MiB), so this is a pure runaway guard that never affects legitimate packages.
- **Sync wall-clock bound (slow-drip DoS).** `urllib`'s `timeout` is per-socket-op, so a server dribbling bytes just under the timeout could stall indefinitely. The new `_read_capped` helper enforces a `time.monotonic()` deadline while reading. The async path's `ClientTimeout(total=...)` already covered this.
- **URL-encode the package name.** Request URLs now use `quote(package, safe="")`.
- **Robust permacache keys.** Cache keys are serialized with `json.dumps`/`json.loads` instead of `"|".join`/`split("|", 1)`, so a package name containing `|` round-trips correctly.

## Response compression

- **Request gzip on the sync path.** PyPI returns responses 5–6× smaller on the wire (numpy ~3 MiB → ~600 KiB). This also makes the 1 s timeout far more likely to succeed on slow links, so the check is more reliable. `build_opener` is used (instead of a `Request` object) so default handlers — notably proxy support — are preserved while setting `Accept-Encoding`. The async path already negotiates gzip via aiohttp.
- **Bounded decompression.** A streaming decompressor caps output at `MAX_RESPONSE_BYTES`, so a small compressed payload can't be expanded into a memory-exhausting one (gzip bomb).

## Tests

6 new tests (39 total): oversized response (sync + async), bounded decompression, gzip happy-path, permacache key round-trip with delimiter characters, and package-name URL encoding. `ruff check` (ALL + preview, **zero noqas**), `ruff format`, `pytest` (3.10–3.14), and `pre-commit` all pass. Verified end-to-end against live PyPI.