### PR TITLE
Validate permacache timestamps on load

### DIFF
--- a/src/update_checker/core.py
+++ b/src/update_checker/core.py
@@ -119,6 +119,10 @@ class _Cache:
             return  # It's okay if it cannot load
         try:
             for raw_key, (cache_time, result) in permacache.items():
+                # A non-numeric cache_time would later crash retrieve, so skip
+                # any entry that is not a real timestamp
+                if not isinstance(cache_time, (int, float)):
+                    continue
                 key = tuple(json.loads(raw_key))
                 if key not in self.results or cache_time > self.results[key][0]:
                     self.results[key] = (cache_time, _deserialize_result(result))

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -22,6 +22,7 @@ from update_checker import (
     update_check,
 )
 from update_checker.core import (
+    CACHE_MISS,
     _Cache,
     _colorize,
     _deserialize_result,
@@ -269,6 +270,22 @@ async def test_async_update_check__unsuccessful(
             package_version="0.0.1",
         )
     assert not capsys.readouterr().err
+
+
+def test_cache_permacache__ignores_non_numeric_timestamp(
+    tmp_path: pathlib.Path,
+) -> None:
+    key = (PACKAGE, "1.0")
+    filename = tmp_path / "cache.json"
+    filename.write_text(json.dumps({json.dumps(key): ["whenever", None]}))
+
+    cache = _Cache()
+    cache.filename = filename
+    cache.initialized = True
+    cache.update_from_permacache()
+    assert key not in cache.results
+    # retrieve must not raise on a poisoned permacache
+    assert cache.retrieve(key) is CACHE_MISS
 
 
 def test_cache_permacache__round_trips_keys_with_special_characters(


### PR DESCRIPTION
Follow-up to the network/cache hardening (#31). A third audit pass found that a corrupt or tampered `cache.json` can break `update_check`'s fail-silent guarantee.

## The bug

- `update_from_permacache` reads `cache_time` from `cache.json`. On the first load, `self.results` is empty, so `key not in self.results` short-circuits the `or` and the `cache_time > ...` comparison — which would otherwise raise and be caught — is **skipped**. A non-numeric timestamp is stored unvalidated.
- `retrieve` then evaluates `time.time() - cache_time`, raising an **uncaught** `TypeError` straight into the caller's program.

`update_check` / `UpdateChecker.check` are designed never to crash the host application (it's an update notifier), so this is an availability bug. Realistic triggers: a same-user process planting a bad cache, or the permacache corruption the code itself documents (concurrent writers / format changes across versions).

## The fix

Validate the timestamp type on load — the single chokepoint, since in-memory writes always use `time.time()`:

```python
if not isinstance(cache_time, (int, float)):
    continue  # skip malformed entry
```

## Test

`test_cache_permacache__ignores_non_numeric_timestamp` writes a poisoned `cache.json` and asserts the entry is skipped and `retrieve` returns `CACHE_MISS` without raising. Verified it **fails without the fix** (the bad entry lands in `results`) and passes with it. 40 tests total; ruff (ALL + preview, zero noqas), format, and pre-commit all pass.