### PR TITLE
Prepare metadata and minor hardening for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+This project adheres to [Semantic Versioning](https://semver.org).
+
+## Unreleased
+
+### Added
+
+- Asynchronous API: `async_update_check`, `UpdateChecker.async_check`, and async
+  counterparts of the helpers, sharing a single core with the synchronous API.
+  Install the optional extra with `uv add "update_checker[async]"`.
+- The update notice written to stderr is colorized (yellow) when stderr is a
+  terminal, honoring the `NO_COLOR` and `FORCE_COLOR` conventions.
+- gzip-compressed responses are requested from PyPI, reducing transfer size and
+  improving the odds of completing within the request timeout on slow links.
+- A `py.typed` marker (PEP 561) so type checkers consume the bundled
+  annotations.
+
+### Changed
+
+- Packaging migrated to uv with a `src` layout and the `uv_build` backend.
+- The update notice no longer reports version-bump metadata.
+
+### Removed
+
+- All runtime dependencies; the package now relies solely on the standard
+  library (`requests` was replaced with `urllib`).
+
+### Fixed
+
+- Release dates are handled as timezone-aware datetimes, fixing incorrect or
+  failed date rendering on modern Python.
+
+### Security
+
+- The on-disk cache is JSON instead of pickle, removing an arbitrary code
+  execution risk (CWE-502) when loading a tampered cache.
+- PyPI responses are bounded in size and read time on both paths, and gzip
+  decompression is bounded against decompression bombs.
+- Package names are URL-encoded in requests.
+- Permacache entries with invalid timestamps are ignored rather than crashing
+  the caller, and the cache file is written with owner-only permissions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,14 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Typing :: Typed",
 ]
 dependencies = []
 description = "A python module that will check for package updates."
@@ -33,7 +36,10 @@ version = "0.18.0"
 async = ["aiohttp"]
 
 [project.urls]
+Changelog = "https://github.com/bboe/update_checker/blob/main/CHANGELOG.md"
 Homepage = "https://github.com/bboe/update_checker"
+Issues = "https://github.com/bboe/update_checker/issues"
+Source = "https://github.com/bboe/update_checker"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/update_checker/core.py
+++ b/src/update_checker/core.py
@@ -44,6 +44,7 @@ REPLACE = {"-": "final-", "dev": "@", "pre": "c", "preview": "c", "rc": "c"}.get
 SECONDS_PER_HOUR = 3600
 SECONDS_PER_MINUTE = 60
 TIMEOUT_SECONDS = 1
+USER_AGENT = f"update_checker/{__version__}"
 
 
 class _Cache:
@@ -99,6 +100,8 @@ class _Cache:
         try:
             with self.filename.open("w") as fp:
                 json.dump(data, fp)
+            # Keep the cache private; it reveals which packages the user runs
+            self.filename.chmod(0o600)
         except OSError:
             pass  # Ignore permacache saving exceptions
 
@@ -300,7 +303,10 @@ async def async_query_pypi(
     timeout = aiohttp.ClientTimeout(total=TIMEOUT_SECONDS)
     try:
         async with (
-            aiohttp.ClientSession(timeout=timeout) as session,
+            aiohttp.ClientSession(
+                headers={"User-Agent": USER_AGENT},
+                timeout=timeout,
+            ) as session,
             session.get(
                 f"https://pypi.org/pypi/{quote(package, safe='')}/json",
             ) as response,
@@ -581,7 +587,7 @@ def query_pypi(*, include_prereleases: bool, package: str) -> dict[str, Any]:
     # build_opener keeps the default handlers (notably proxy support) while
     # letting us request a gzip-compressed response
     opener = urllib.request.build_opener()
-    opener.addheaders = [("Accept-Encoding", "gzip")]
+    opener.addheaders = [("Accept-Encoding", "gzip"), ("User-Agent", USER_AGENT)]
     url = f"https://pypi.org/pypi/{quote(package, safe='')}/json"
     try:
         # open raises HTTPError, an OSError, for non-2xx responses

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -6,6 +6,7 @@ import gzip
 import io
 import json
 import os
+import sys
 import urllib.error
 from datetime import datetime, timedelta, timezone
 from functools import partial
@@ -23,6 +24,7 @@ from update_checker import (
 )
 from update_checker.core import (
     CACHE_MISS,
+    USER_AGENT,
     _Cache,
     _colorize,
     _deserialize_result,
@@ -303,6 +305,18 @@ def test_cache_permacache__round_trips_keys_with_special_characters(
     assert key in reader.results
 
 
+def test_cache_permacache__written_with_owner_only_permissions(
+    tmp_path: pathlib.Path,
+) -> None:
+    if sys.platform == "win32":
+        return  # POSIX permission bits are not meaningful on Windows
+    cache = _Cache()
+    cache.filename = tmp_path / "cache.json"
+    cache.initialized = True
+    cache.store(key=(PACKAGE, "1.0"), value=None)
+    assert cache.filename.stat().st_mode & 0o777 == 0o600
+
+
 def test_checker_check__gzip_encoded_response() -> None:
     body = gzip.compress(json.dumps({"releases": {"0.0.1": [], "5.0.0": []}}).encode())
     with fake_sync_pypi(body, content_encoding="gzip"):
@@ -425,6 +439,22 @@ def test_query_pypi__quotes_package_name() -> None:
     with fake_sync_pypi({}) as opener_open:
         query_pypi(include_prereleases=False, package="a/b c")
     assert opener_open.call_args.args[0] == "https://pypi.org/pypi/a%2Fb%20c/json"
+
+
+def test_query_pypi__sets_user_agent() -> None:
+    captured: dict[str, list[tuple[str, str]]] = {}
+
+    def fake_open(opener: object, _url: str, /, **_kwargs: object) -> FakeSyncResponse:
+        captured["headers"] = opener.addheaders
+        return FakeSyncResponse(b"{}")
+
+    with mock.patch(
+        "urllib.request.OpenerDirector.open",
+        autospec=True,
+        side_effect=fake_open,
+    ):
+        query_pypi(include_prereleases=False, package=PACKAGE)
+    assert ("User-Agent", USER_AGENT) in captured["headers"]
 
 
 def test_serialize_result__round_trip() -> None:


### PR DESCRIPTION
Pre-release polish identified in a final review pass. No functional change to the update-check behavior; no version bump (that's a separate step).

## Changes

- **`py.typed` marker (PEP 561)** + `Typing :: Typed` classifier — the package is fully annotated but, without this, downstream type checkers ignored the annotations. Verified the marker ships in the built wheel.
- **CHANGELOG.md** — summarizes everything since 0.18.0 (async, gzip, colorize, zero-deps, the security hardening) under an `Unreleased` section, ready to date when 0.19.0 is cut.
- **Richer PyPI metadata** — added `Changelog`, `Issues`, and `Source` project URLs and the `Programming Language :: Python :: 3 :: Only` and `Topic :: Software Development` classifiers.
- **User-Agent** — requests now send `update_checker/<version>` on both the sync and async paths (politeness / traffic attribution), instead of the bare `Python-urllib`/`aiohttp` defaults.
- **Cache file permissions** — the permacache is written `0o600`; it reveals which packages/versions the user runs, so it shouldn't be world-readable. POSIX-only; a no-op on Windows.

## Tests

2 new tests (42 total): the sync request attaches the `User-Agent` header, and the permacache is written with owner-only permissions (POSIX-guarded). `ruff` (ALL + preview, zero noqas), `ruff format`, `pytest` (3.10–3.14), and `pre-commit` all pass. Verified end-to-end against live PyPI.