### PR TITLE
Type-check with pyright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,10 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: "3.13"
-      - run: uv sync --group lint
+      - run: uv sync --group lint --group typecheck
       - run: uv run ruff check .
       - run: uv run ruff format --check .
+      - run: uv run pyright
   test:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,10 @@ build-backend = "uv_build"
 requires = ["uv_build>=0.8.0,<1.0"]
 
 [dependency-groups]
-dev = [{include-group = "lint"}, {include-group = "test"}]
+dev = [{include-group = "lint"}, {include-group = "test"}, {include-group = "typecheck"}]
 lint = ["pre-commit", "ruff"]
 test = ["aiohttp", "pytest", "pytest-asyncio"]
+typecheck = ["aiohttp", "pyright"]
 
 [project]
 authors = [{name = "Bryce Boe", email = "bbzbryce@gmail.com"}]
@@ -40,6 +41,10 @@ Changelog = "https://github.com/bboe/update_checker/blob/main/CHANGELOG.md"
 Homepage = "https://github.com/bboe/update_checker"
 Issues = "https://github.com/bboe/update_checker/issues"
 Source = "https://github.com/bboe/update_checker"
+
+[tool.pyright]
+include = ["src"]
+pythonVersion = "3.10"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/update_checker/core.py
+++ b/src/update_checker/core.py
@@ -14,10 +14,11 @@ import time
 import urllib.request
 import zlib
 from datetime import datetime, timezone
+from enum import Enum, auto
 from functools import wraps
 from http import HTTPStatus
 from importlib.metadata import version
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 from urllib.parse import quote
 
 try:
@@ -31,7 +32,23 @@ if TYPE_CHECKING:
 
 __version__ = version("update_checker")
 
-CACHE_MISS = object()
+
+class _Sentinel(Enum):
+    """Distinct sentinel type so a cache miss narrows away from a result."""
+
+    CACHE_MISS = auto()
+
+
+class _SerializedResult(TypedDict):
+    """The JSON-serializable form of an UpdateResult in the permacache."""
+
+    available: str
+    package: str
+    release_date: str | None
+    running: str
+
+
+CACHE_MISS = _Sentinel.CACHE_MISS
 CHUNK_SIZE = 65536
 # COMPONENT_RE and REPLACE support parse_version near the bottom of this module
 COMPONENT_RE = re.compile(r"(\d+ | [a-z]+ | \.| -)", re.VERBOSE)
@@ -68,7 +85,7 @@ class _Cache:
             return  # Operate without a permacache
         self.update_from_permacache()
 
-    def retrieve(self, key: tuple[str, str], /) -> UpdateResult | object | None:
+    def retrieve(self, key: tuple[str, str], /) -> UpdateResult | _Sentinel | None:
         """Return the fresh cached result for key, or the CACHE_MISS sentinel.
 
         Returns:
@@ -92,16 +109,19 @@ class _Cache:
         in-tact.
 
         """
+        filename = self.filename
+        if filename is None:
+            return
         self.update_from_permacache()
         data = {
             json.dumps(key): [cache_time, _serialize_result(result)]
             for key, (cache_time, result) in self.results.items()
         }
         try:
-            with self.filename.open("w") as fp:
+            with filename.open("w") as fp:
                 json.dump(data, fp)
             # Keep the cache private; it reveals which packages the user runs
-            self.filename.chmod(0o600)
+            filename.chmod(0o600)
         except OSError:
             pass  # Ignore permacache saving exceptions
 
@@ -115,8 +135,11 @@ class _Cache:
 
     def update_from_permacache(self) -> None:
         """Attempt to update newer items from the permacache."""
+        filename = self.filename
+        if filename is None:
+            return
         try:
-            with self.filename.open() as fp:
+            with filename.open() as fp:
                 permacache = json.load(fp)
         except (OSError, ValueError):
             return  # It's okay if it cannot load
@@ -431,7 +454,7 @@ def _colorize(text: str, /) -> str:
     return f"\033[33m{text}\033[0m"
 
 
-def _deserialize_result(data: dict[str, str | None] | None, /) -> UpdateResult | None:
+def _deserialize_result(data: _SerializedResult | None, /) -> UpdateResult | None:
     if data is None:
         return None
     return UpdateResult(
@@ -644,7 +667,7 @@ def _result_from_data(
     )
 
 
-def _serialize_result(result: UpdateResult | None, /) -> dict[str, str | None] | None:
+def _serialize_result(result: UpdateResult | None, /) -> _SerializedResult | None:
     if result is None:
         return None
     return {

--- a/uv.lock
+++ b/uv.lock
@@ -712,6 +712,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.410"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -922,6 +935,7 @@ async = [
 dev = [
     { name = "aiohttp" },
     { name = "pre-commit" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -934,6 +948,10 @@ test = [
     { name = "aiohttp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+]
+typecheck = [
+    { name = "aiohttp" },
+    { name = "pyright" },
 ]
 
 [package.metadata]
@@ -944,6 +962,7 @@ provides-extras = ["async"]
 dev = [
     { name = "aiohttp" },
     { name = "pre-commit" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -956,6 +975,10 @@ test = [
     { name = "aiohttp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+]
+typecheck = [
+    { name = "aiohttp" },
+    { name = "pyright" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a pyright type gate to CI and fixes the issues it surfaced, backing the `py.typed` promise added in #33.

**Stacked on #33** (`release-prep`) — GitHub will retarget this to `main` once #33 merges.

## Fixes (8 pyright errors, none were runtime bugs)

All were cases where the types were looser than the runtime guarantees:

- **Cache-miss sentinel** — `CACHE_MISS = object()` typed as `object`, so `if result is not CACHE_MISS` couldn't narrow and `retrieve` "returned" `object`. Replaced with a single-member `_Sentinel` enum, which pyright narrows on identity → `retrieve` returns `UpdateResult | _Sentinel | None` and callers see `UpdateResult | None` after the check.
- **Permacache payload** — added a `_SerializedResult` `TypedDict` so the serialized fields type as `str` / `str | None` instead of `dict[str, str | None]`, removing the three `str | None`-into-`str` errors in `_deserialize_result`.
- **`_Cache.filename` (`Path | None`)** — narrowed via a local variable before `open()`/`chmod()` in the two permacache methods.

## CI wiring

- New `typecheck` dependency-group: `aiohttp` (so imports resolve) + `pyright`.
- `[tool.pyright]` scoped to `src` and pinned to `pythonVersion = "3.10"` (the support floor), so the gate also catches 3.10-incompatible typing.
- `uv run pyright` added to the lint job.

`tests/` are intentionally out of scope for now (they lean on `mock` and would add noise); can be folded in later.

Locally: ruff (ALL + preview, zero noqas), ruff format, **pyright 0 errors**, pytest 3.10–3.14 (42), and pre-commit all pass.