### PR TITLE
Release 1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+jobs:
+  pypi:
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          python-version: "3.13"
+      - run: uv build
+      - run: uv publish --trusted-publishing always
+
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org).
 
-## Unreleased
+## 1.0.0 - 2026-06-08
+
+First stable release, marking a commitment to the current public API.
 
 ### Added
 
@@ -18,6 +20,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- The helpers and `UpdateChecker` methods now take keyword-only arguments;
+  `update_check(package_name, package_version)` remains positional.
 - Packaging migrated to uv with a `src` layout and the `uv_build` backend.
 - The update notice no longer reports version-bump metadata.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license-files = ["LICENSE.txt"]
 name = "update_checker"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.18.0"
+version = "1.0.0"
 
 [project.optional-dependencies]
 async = ["aiohttp"]

--- a/uv.lock
+++ b/uv.lock
@@ -923,7 +923,7 @@ wheels = [
 
 [[package]]
 name = "update-checker"
-version = "0.18.0"
+version = "1.0.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Cuts the first stable release, `1.0.0`.

## Changes

- **Version** bumped `0.18.0` → `1.0.0`. The major bump reflects the now-stable, keyword-only public API (`update_check(package_name, package_version)` stays positional for praw/asyncpraw compatibility).
- **CHANGELOG** `Unreleased` section finalized as `1.0.0 - 2026-06-08`.
- **`release.yml`** — publishes to PyPI via **OIDC trusted publishing** (no stored token) on a `v*` tag push. SHA-pinned actions, top-level `permissions: {}`, the publish job scoped to `contents: read` + `id-token: write` in a dedicated `pypi` environment.

Verified locally: builds as `1.0.0` (sdist + wheel), ruff + pyright + 42 tests pass.

## Required one-time setup before tagging (PyPI side)

For the trusted-publishing workflow to authenticate, configure a trusted publisher on PyPI **before** the `v1.0.0` tag is pushed:

- PyPI → `update_checker` → **Publishing** → **Add a pending/trusted publisher**
  - Owner: `bboe`
  - Repository: `update_checker`
  - Workflow filename: `release.yml`
  - Environment: `pypi`
- GitHub → repo **Settings → Environments** → create an environment named `pypi` (optionally add a required-reviewer protection rule on releases).

## Release sequence after merge

1. Merge this PR.
2. Complete the PyPI + GitHub `pypi` environment setup above.
3. Push tag `v1.0.0` → the workflow builds and publishes to PyPI.