### PR TITLE
Use reusable workflows (CI + publish); add pyright pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,35 +1,13 @@
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
-        with:
-          python-version: "3.13"
-      - run: uv sync --group lint --group typecheck
-      - run: uv run ruff check .
-      - run: uv run ruff format --check .
-      - run: uv run pyright
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: uv sync --group test
-      - run: uv run pytest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-
 name: CI
 
 on:
-  pull_request:
   push:
     branches: [main]
+  pull_request:
 
 permissions:
   contents: read
+
+jobs:
+  ci:
+    uses: bboe/.github/.github/workflows/python-ci.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,16 @@
-jobs:
-  pypi:
-    environment: pypi
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
-        with:
-          python-version: "3.13"
-      - run: uv build
-      - run: uv publish --trusted-publishing always
-
 name: Release
 
 on:
   push:
     tags: ["v*"]
 
-permissions: {}
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    permissions:
+      contents: read
+      id-token: write
+    uses: bboe/.github/.github/workflows/pypi-publish.yml@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,11 @@ repos:
       - id: ruff-format
     repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.16
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: uv run --group typecheck pyright
+        language: system
+        types: [python]
+        pass_filenames: false


### PR DESCRIPTION
- CI and release now call the reusable `bboe/.github` workflows.
- Adds a local `pyright` pre-commit hook so lint coverage (now run via pre-commit in CI) keeps pyright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)